### PR TITLE
Fixes #17965 - compatibility with hammer-cli >= 0.9.0

### DIFF
--- a/lib/hammer_cli_foreman_openscap/commands.rb
+++ b/lib/hammer_cli_foreman_openscap/commands.rb
@@ -5,9 +5,19 @@ module HammerCLIForemanOpenscap
     end
 
     module ClassMethods
+      def api_connection
+        if HammerCLI.context[:api_connection]
+          HammerCLI.context[:api_connection].get("foreman")
+        else
+          HammerCLI::Connection.get("foreman").api
+        end
+      end
+
       def resolver
-        api = HammerCLI::Connection.get("foreman").api
-        HammerCLIForeman::IdResolver.new(api, HammerCLIForemanOpenscap::Searchables.new)
+        HammerCLIForeman::IdResolver.new(
+          api_connection,
+          HammerCLIForemanOpenscap::Searchables.new
+        )
       end
 
       def searchables


### PR DESCRIPTION
Hammer core 0.9.0 contains changes in api connections.

This patch fixes `Error: undefined method 'get' for HammerCLI::Connection:Class` error that appears when using `hammer policy create ...`