### PR TITLE
Fixes #20681 - extend core commands with openscap proxy

### DIFF
--- a/lib/hammer_cli_foreman_openscap.rb
+++ b/lib/hammer_cli_foreman_openscap.rb
@@ -4,6 +4,8 @@ require 'hammer_cli_foreman_openscap/id_resolver'
 require 'hammer_cli_foreman_openscap/commands'
 require 'hammer_cli_foreman_openscap/error'
 require 'hammer_cli_foreman_openscap/exception_handler'
+require 'hammer_cli_foreman_openscap/hostgroup'
+require 'hammer_cli_foreman_openscap/host'
 
 module HammerCLIForemanOpenscap
   def self.exception_handler_class

--- a/lib/hammer_cli_foreman_openscap/host.rb
+++ b/lib/hammer_cli_foreman_openscap/host.rb
@@ -1,0 +1,2 @@
+require 'hammer_cli_foreman/host'
+require 'hammer_cli_foreman_openscap/host_extensions'

--- a/lib/hammer_cli_foreman_openscap/host_extensions.rb
+++ b/lib/hammer_cli_foreman_openscap/host_extensions.rb
@@ -1,0 +1,9 @@
+require 'hammer_cli_foreman/host'
+
+module HammerCLIForemanOpenscap
+  ::HammerCLIForeman::Host::InfoCommand.instance_eval do
+    output do
+      field :openscap_proxy_id, _('OpenSCAP Proxy')
+    end
+  end
+end

--- a/lib/hammer_cli_foreman_openscap/hostgroup.rb
+++ b/lib/hammer_cli_foreman_openscap/hostgroup.rb
@@ -1,0 +1,2 @@
+require 'hammer_cli_foreman/hostgroup'
+require 'hammer_cli_foreman_openscap/hostgroup_extensions'

--- a/lib/hammer_cli_foreman_openscap/hostgroup_extensions.rb
+++ b/lib/hammer_cli_foreman_openscap/hostgroup_extensions.rb
@@ -1,0 +1,9 @@
+require 'hammer_cli_foreman/hostgroup'
+
+module HammerCLIForemanOpenscap
+  ::HammerCLIForeman::Hostgroup::InfoCommand.instance_eval do
+    output do
+      field :openscap_proxy_id, _('OpenSCAP Proxy')
+    end
+  end
+end


### PR DESCRIPTION
Requires https://github.com/theforeman/foreman_openscap/pull/282 but does not do any harm without. It would only print empty openscap proxy id in hostgroup/host show.