### PR TITLE
Fixes #26593 - Add command for policies in ENC

### DIFF
--- a/lib/hammer_cli_foreman_openscap.rb
+++ b/lib/hammer_cli_foreman_openscap.rb
@@ -1,4 +1,5 @@
 require 'hammer_cli_foreman'
+require 'hammer_cli_foreman/host'
 require 'hammer_cli_foreman_openscap/options/normalizers'
 require 'hammer_cli_foreman_openscap/id_resolver'
 require 'hammer_cli_foreman_openscap/commands'
@@ -29,4 +30,8 @@ module HammerCLIForemanOpenscap
   HammerCLI::MainCommand.lazy_subcommand("tailoring-file", _("Manipulate Tailoring files"),
                                          "HammerCLIForemanOpenscap::TailoringFile",
                                          "hammer_cli_foreman_openscap/tailoring_file")
+
+  HammerCLIForeman::Host.lazy_subcommand(Host::PoliciesEnc.command_name, _('View policies ENC for host'),
+                                        "HammerCLIForemanOpenscap::Host::PoliciesEnc",
+                                        "hammer_cli_foreman_openscap/host")
 end

--- a/lib/hammer_cli_foreman_openscap/host.rb
+++ b/lib/hammer_cli_foreman_openscap/host.rb
@@ -1,2 +1,30 @@
 require 'hammer_cli_foreman/host'
 require 'hammer_cli_foreman_openscap/host_extensions'
+
+module HammerCLIForemanOpenscap
+  class Host < HammerCLIForeman::Command
+    resource :hosts
+
+    class PoliciesEnc < HammerCLIForeman::ListCommand
+      command_name "policies-enc"
+      action :policies_enc
+
+      output do
+        field :id, _('Id')
+        field :profile_id, _('Profile Id')
+        field :content_path, _('Content path')
+        field :download_path, _('Content download path')
+        field :tailoring_path, _('Tailoring path')
+        field :tailoring_download_path, _('Tailoring download path')
+        field :monthday, _('Day of month')
+        field :hour, _('Hour')
+        field :minute, ('Minute')
+        field :month, _('Month')
+        field :week, _('Week')
+      end
+
+      build_options
+    end
+    autoload_subcommands
+  end
+end

--- a/lib/hammer_cli_foreman_openscap/host.rb
+++ b/lib/hammer_cli_foreman_openscap/host.rb
@@ -23,6 +23,10 @@ module HammerCLIForemanOpenscap
         field :week, _('Week')
       end
 
+      def adapter
+        @context[:adapter] || :base
+      end
+
       build_options
     end
     autoload_subcommands


### PR DESCRIPTION
There are too many columns and they are too wide, the table does not look good:

![table-list](https://user-images.githubusercontent.com/2664090/55967927-65ca4b80-5c7b-11e9-9984-b6307453c030.png)

It is much better when I use json:

![list-json](https://user-images.githubusercontent.com/2664090/55968006-8a262800-5c7b-11e9-82ad-3936c0b07a4e.png)

So I switched to from `ListCommand` to `InfoCommand` and it looks much better:

![info-table](https://user-images.githubusercontent.com/2664090/55968166-c5285b80-5c7b-11e9-90fc-5ba1e6f582c1.png)

Unfortunately, the json now shows only 1 item:

![info-json](https://user-images.githubusercontent.com/2664090/55968222-e4bf8400-5c7b-11e9-919d-7247e887a5d3.png)


@mbacovsky, is `InfoCommand` supposed to work with a collection or is it a bug? Any chance hammer could give me results from screenshots 2 and 3 out of the box or do I need to do it on my own?




