### PR TITLE
Fixes #30491 - show digest info in hammer command

### DIFF
--- a/lib/hammer_cli_foreman_openscap/scap_content.rb
+++ b/lib/hammer_cli_foreman_openscap/scap_content.rb
@@ -7,6 +7,7 @@ module HammerCLIForemanOpenscap
       output do
         field :id, _("Id")
         field :title, _("Title")
+        field :digest, _("Digest")
       end
       build_options
     end


### PR DESCRIPTION
After this patch

~~~
# hammer scap-content info --id 4
Id:                    4
Title:                 Red Hat rhel7 default content
Digest:                96c2a9d5278d5da905221bbb2dc61d0ace7ee3d97f021fccac994d26296d986d
Created at:            2020-07-25 01:57:55 UTC
Original filename:     ssg-rhel7-ds.xml
SCAP content profiles: 
    Id:         16
    Profile id: xccdf_org.ssgproject.content_profile_hipaa
    Title:      Health Insurance Portability and Accountability Act (HIPAA)
    Id:         17

~~~