### PR TITLE
use correct GPL-3.0 license identifier in gemspec

### DIFF
--- a/hammer_cli_foreman_openscap.gemspec
+++ b/hammer_cli_foreman_openscap.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version = HammerCLIForemanOpenscap.version.dup
   s.platform = Gem::Platform::RUBY
   s.summary = %q{Foreman OpenSCAP commands for Hammer}
-  s.license = "GPL-3"
+  s.license = "GPL-3.0"
   s.files = Dir['{lib,config,locale}/**/*', 'LICENSE', 'README.md']
   s.require_paths = ["lib"]
   s.test_files = Dir["test/**/*"]


### PR DESCRIPTION
Fixes: 7468ff068363b8cf235cc96d17c2e2dc9b3c573e