### PR TITLE
Relax hammer_cli_foreman dependency to allow 5.x

### DIFF
--- a/hammer_cli_foreman_openscap.gemspec
+++ b/hammer_cli_foreman_openscap.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
   s.homepage = 'https://github.com/theforeman/hammer_cli_foreman_openscap'
 
-  s.add_dependency 'hammer_cli_foreman', '>= 0.19', '< 4.0'
+  s.add_dependency 'hammer_cli_foreman', '>= 0.19', '< 6.0'
 
   s.required_ruby_version = '>= 2.7', '< 4'
 end


### PR DESCRIPTION
## Summary
- Relax the hammer_cli_foreman version constraint to < 6.0 to allow compatibility with the upcoming 5.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)